### PR TITLE
🐞 fix: 修复安装依赖预先执行preintsall

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "preinstall": "npx concurrently \"cd ./cxy-home && pnpm install\" \"cd ./cxy-home-competition && pnpm install\" \"cd ./cxy-home-activity && pnpm install\" \"cd ./cxy-home-login && pnpm install\"",
+    "allinstall": "npx concurrently \"cd ./cxy-home && pnpm install\" \"cd ./cxy-home-competition && pnpm install\" \"cd ./cxy-home-activity && pnpm install\" \"cd ./cxy-home-login && pnpm install\"",
     "alldev": "npx concurrently \"cd ./cxy-home && pnpm dev\" \"cd ./cxy-home-activity && pnpm dev -p 3001\" \"cd ./cxy-home-competition && pnpm dev -p 3002\" \"cd ./cxy-home-login && pnpm dev -p 3003\"",
     "allbuild": "npx concurrently \"cd ./cxy-home && pnpm build\" \"cd ./cxy-home-activity && pnpm build\" \"cd ./cxy-home-competition && pnpm build\" \"cd ./cxy-home-login && pnpm build\"",
     "allstart": "pnpm allbuild && npx concurrently \"cd ./cxy-home && pnpm dev\" \"cd ./cxy-home-activity && pnpm dev -p 3001\" \"cd ./cxy-home-competition && pnpm dev -p 3002\" \"cd ./cxy-home-login && pnpm dev -p 3003\""


### PR DESCRIPTION
install packages时会预先执行preinstall导致获取不到项目